### PR TITLE
fix:fix record.GetString panic bug because of out range of index of r.sst.Rgb

### DIFF
--- a/xls/record/labelSst.go
+++ b/xls/record/labelSst.go
@@ -40,7 +40,11 @@ func (r *LabelSSt) GetCol() [2]byte {
 }
 
 func (r *LabelSSt) GetString() string {
-	return r.sst.Rgb[helpers.BytesToUint32(r.isst[:])].String()
+	index := helpers.BytesToUint32(r.isst[:])
+	if index < uint32(len(r.sst.Rgb)) {
+		return r.sst.Rgb[index].String()
+	}
+	return ""
 }
 
 func (r *LabelSSt) GetFloat64() (fl float64) {
@@ -57,9 +61,6 @@ func (r *LabelSSt) GetType() string {
 func (r *LabelSSt) GetXFIndex() int {
 	return int(helpers.BytesToUint16(r.ixfe[:]))
 }
-
-
-
 
 func (r *LabelSSt) Read(stream []byte, sst *SST) {
 	r.sst = sst


### PR DESCRIPTION
fix:fix record.GetString panic bug because of out range of index of r.sst.Rgb